### PR TITLE
fix: deprecated set-output in GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: marocchino/tool-versions-action@v1
       - name: Get current date
         id: time
-        run: echo "::set-output name=unix::$(date +'%s')"
+        run: echo "unix=$(date +'%s')" >> $GITHUB_OUTPUT
       - name: Cache deps and _build
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Due to deprecation of `save-state` and `set-output` commands in GitHub Action workflows, this PR should prevent workflows to fail after the 31st May 2023.

Please verify that the workflow is behaving as expected :)

Link to GitHub blogg:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Old way of working
```yaml
- name: Save state
  run: echo "::save-state name={name}::{value}"
- name: Set output
  run: echo "::set-output name={name}::{value}"
```

New way of working
```yaml
- name: Save state
  run: echo "{name}={value}" >> $GITHUB_STATE
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```